### PR TITLE
Bring over GUI Portal rendering fix from main Fabric mod.

### DIFF
--- a/src/main/java/qouteall/imm_ptl/core/api/example/ExampleGuiPortalRendering.java
+++ b/src/main/java/qouteall/imm_ptl/core/api/example/ExampleGuiPortalRendering.java
@@ -184,12 +184,12 @@ public class ExampleGuiPortalRendering {
             // Draw the framebuffer
             int h = minecraft.getWindow().getHeight();
             int w = minecraft.getWindow().getWidth();
-            MyRenderHelper.drawFramebuffer(
+            MyRenderHelper.drawFramebufferWithBounds(
                 frameBuffer,
                 true, // enable alpha blend
                 false, // don't modify alpha
-                w * 0.2f, w * 0.8f,
-                h * 0.2f, h * 0.8f
+                (int) (w * 0.2f), (int) (w * 0.8f),
+                (int) (h * 0.2f), (int) (h * 0.8f)
             );
             
             guiGraphics.drawCenteredString(


### PR DESCRIPTION
This fix was accepted in the [main Fabric mod](https://github.com/iPortalTeam/ImmersivePortalsMod/pull/1658). Retains original methods for continuity, but adds two methods to allow GUI Portals to render anywhere on the screen rather than just the bottom-left corner.