### PR TITLE
Fix SecurityCraft compatibility and Stitch dependency issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ repositories {
         name "tterrag maven"
         url "https://maven.tterrag.com/"
     }
+    maven {
+        name "Fabric"
+        url "https://maven.fabricmc.net/"
+    }
 
     flatDir {
         dir "deps"
@@ -154,7 +158,7 @@ dependencies {
     implementation "maven.modrinth:oritech:0.16.2"
     implementation "maven.modrinth:architectury-api:13.0.8+neoforge"
     implementation "maven.modrinth:geckolib:DTo3uxPN"
-    implementation "maven.modrinth:stitch:4.0.1"
+    implementation "net.fabricmc:stitch:0.6.2"
 
     // Create
     implementation "maven.modrinth:create:1.21.1-6.0.6"

--- a/src/main/java/qouteall/imm_ptl/core/mixin/common/chunk_sync/MixinChunkMap_C.java
+++ b/src/main/java/qouteall/imm_ptl/core/mixin/common/chunk_sync/MixinChunkMap_C.java
@@ -67,13 +67,14 @@ public abstract class MixinChunkMap_C implements IEChunkMap {
         ci.cancel();
     }
     
-    /**
-     * @author qouteall
-     * @reason
-     */
-    @Overwrite
-    private void onChunkReadyToSend(LevelChunk chunk) {
+    @Inject(
+        method = "onChunkReadyToSend",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private void onOnChunkReadyToSend(LevelChunk chunk, CallbackInfo ci) {
         ImmPtlChunkTracking.onChunkProvidedDeferred(chunk);
+        ci.cancel();
     }
 
     /**


### PR DESCRIPTION
## Summary
  This PR fixes critical compatibility issues that cause server crashes when Immersive Portals is used
  alongside SecurityCraft and resolves build failures due to incorrect Stitch library configuration.

  ## Changes
  1. **Fixed SecurityCraft mixin conflict**: Replaced `@Overwrite` with `@Inject` annotation in
  `MixinChunkMap_C.java` for the `onChunkReadyToSend` method
  2. **Added Fabric Maven repository**: Required for resolving `net.fabricmc` dependencies (wasn't found in maven while building)
  3. **Fixed Stitch dependency**: Corrected from `maven.modrinth:stitch:4.0.1` to
  `net.fabricmc:stitch:0.6.2`

  ## Problem Solved
  - **Server crash fix**: Resolves `MixinApplyError` when SecurityCraft tries to inject into
  `onChunkReadyToSend` method
  - **Build failure fix**: Resolves "Could not find maven.modrinth:stitch:4.0.1" error during compilation

  ## Testing                                                                                                    
  - ✅ Build compiles successfully with `./gradlew compileJava`
  - ✅ Server starts without crashes when both Immersive Portals and SecurityCraft are installed                
  - ✅ Maintains existing Immersive Portals chunk tracking functionality
                                                                                                                
  ## Error Details
  The original error occurred because SecurityCraft's `ChunkMapMixin` couldn't inject into
  `onChunkReadyToSend` method due to Immersive Portals using `@Overwrite` with the same priority (1100).
  This PR changes the approach to use `@Inject` with cancellation, allowing other mods to also hook into
  this method without conflicts.

  ## Related Issues
  Fixes compatibility with SecurityCraft mod and resolves build dependency issues.