### PR TITLE
Fix Sodium 0.8.x, Iris depth-buffer, and Distant Horizons compat issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,13 @@ repositories {
         name "tterrag maven"
         url "https://maven.tterrag.com/"
     }
+    maven {
+        // CaffeineMC publishes unwrapped Sodium artifacts here, unlike Modrinth's maven
+        // which packages the real classes inside a JarInJar shim that Gradle's compile
+        // classpath can't see through.
+        name "CaffeineMC"
+        url "https://maven.caffeinemc.net/releases"
+    }
 
     flatDir {
         dir "deps"
@@ -133,8 +140,17 @@ dependencies {
     /*implementation "maven.modrinth:embeddium:Na1PoLYF"
     compileOnly "maven.modrinth:oculus:1.20.1-1.6.15a"*/
 
-    implementation "maven.modrinth:sodium:mc1.21.1-0.6.13-neoforge"
+    // Modrinth's published sodium jar wraps the real mod classes in a JarInJar shim that
+    // Gradle's compile classpath can't see through, so compile against CaffeineMC's own
+    // maven instead, which publishes the classes unwrapped.
+    compileOnly "net.caffeinemc:sodium-neoforge:0.8.12+mc1.21.1"
+    compileOnly "net.caffeinemc:sodium-neoforge-mod:0.8.12+mc1.21.1"
+    compileOnly "net.caffeinemc:sodium-neoforge-api:0.8.12+mc1.21.1"
     implementation "maven.modrinth:iris:1.8.1+1.21.1-neoforge"
+
+    // Distant Horizons compat mixin -- its classes aren't jarjar-wrapped, so Modrinth's
+    // published artifact works directly with no extraction workaround needed.
+    compileOnly "maven.modrinth:distanthorizons:3.2.0-b-1.21.1"
 
     implementation "maven.modrinth:cloth-config:15.0.140+neoforge"
     implementation "maven.modrinth:pehkui:3.8.3+1.21-neoforge"
@@ -154,7 +170,7 @@ dependencies {
     implementation "maven.modrinth:oritech:0.16.2"
     implementation "maven.modrinth:architectury-api:13.0.8+neoforge"
     implementation "maven.modrinth:geckolib:DTo3uxPN"
-    implementation "maven.modrinth:stitch:4.0.1"
+    // implementation "maven.modrinth:stitch:4.0.1" // no longer resolvable on Modrinth maven, unrelated to sodium fix
 
     // Create
     implementation "maven.modrinth:create:1.21.1-6.0.6"

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project tries to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased Changes]
-None currently
+
+### Fixed
+
+- Sodium 0.8.x compat: `OcclusionCuller.Visitor` was promoted to a top-level
+  interface (`RenderSectionVisitor`), and `Viewport.isBoxVisible`'s old
+  6-float AABB signature was split into `isBoxVisible(int,int,int)` and
+  `isBoxVisibleDirect(float,float,float,float)`.
+- Portals rendering through occluding geometry (or falling back to
+  compatibility mode) with a shaderpack active, caused by the deferred
+  framebuffer's depth-stencil format not matching Iris's actual main
+  render target format.
+- Framebuffer thrashing/stutter caused by resizing the deferred
+  framebuffer array every time the lag-adaptive portal layer count
+  toggled.
+- Severe stutter (frame time spikes to 900ms+) when a portal is visible
+  with Distant Horizons installed, caused by DH doing synchronous LOD
+  generation for the portal's alternate-world view every frame.
 
 ## [6.0.7] - 2025-06-18
 

--- a/src/main/java/qouteall/imm_ptl/core/compat/IPCompatMixinPlugin.java
+++ b/src/main/java/qouteall/imm_ptl/core/compat/IPCompatMixinPlugin.java
@@ -49,7 +49,12 @@ public class IPCompatMixinPlugin implements IMixinConfigPlugin {
             boolean cardinalCompLoaded = modList.getModFileById("cardinal-components-base") != null;
             return cardinalCompLoaded;
         }
-        
+
+        if (mixinClassName.contains("Dh")) {
+            boolean distantHorizonsLoaded = modList.getModFileById("distanthorizons") != null;
+            return distantHorizonsLoaded;
+        }
+
         return false;
     }
     

--- a/src/main/java/qouteall/imm_ptl/core/compat/iris_compatibility/IrisPortalRenderer.java
+++ b/src/main/java/qouteall/imm_ptl/core/compat/iris_compatibility/IrisPortalRenderer.java
@@ -68,20 +68,45 @@ public class IrisPortalRenderer extends PortalRenderer {
         // As I tested, in Nvidia videocard, glCopyImageSubData can convert depth32 into depth24stencil8.
         // but in AMD videocard it cannot. AMD videocard only supports converting depth32 into depth32stencil8.
         IPCGlobal.useSeparatedStencilFormat = !IPMcHelper.isNvidiaVideocard();
-        
-        if (deferredFbs.length != PortalRendering.getMaxPortalLayer() + 1) {
+
+        // Size the array off the static configured max, not PortalRendering.getMaxPortalLayer()
+        // (which drops to 1 whenever RenderStates.isLaggy is true). Sizing off the dynamic value
+        // caused a destroy-and-recreate of every deferred framebuffer each time isLaggy toggled,
+        // which is itself expensive enough to cause more lag -- a self-sustaining stutter cycle.
+        // The lag-adaptive behavior still works: it just limits how many of these pre-allocated
+        // slots actually get rendered into, rather than deallocating and reallocating them.
+        if (deferredFbs.length != IPGlobal.maxPortalLayer + 1) {
             for (SecondaryFrameBuffer fb : deferredFbs) {
                 fb.fb.destroyBuffers();
             }
-            
-            deferredFbs = new SecondaryFrameBuffer[PortalRendering.getMaxPortalLayer() + 1];
+
+            deferredFbs = new SecondaryFrameBuffer[IPGlobal.maxPortalLayer + 1];
             for (int i = 0; i < deferredFbs.length; i++) {
                 deferredFbs[i] = new SecondaryFrameBuffer();
             }
+
+            // The vendor heuristic above doesn't reliably match what the main render target's
+            // depth texture actually ends up as once Iris has touched it (a GPU-vendor-detection
+            // timing issue relative to when the main target's buffers were allocated). Query its
+            // real current internal format and let that override the heuristic, so the newly
+            // (re)created deferred FBs below match reality instead of a guess. Only needs doing
+            // when the FBs are (re)created, not every frame, since the format is baked in once.
+            RenderTarget mainTargetForFormatCheck = client.getMainRenderTarget();
+            int mainDepthTexForFormatCheck = mainTargetForFormatCheck.getDepthTextureId();
+            if (mainDepthTexForFormatCheck > 0) {
+                GL11.glBindTexture(GL11.GL_TEXTURE_2D, mainDepthTexForFormatCheck);
+                int mainFormatForFormatCheck = GL11.glGetTexLevelParameteri(GL11.GL_TEXTURE_2D, 0, GL11.GL_TEXTURE_INTERNAL_FORMAT);
+                GL11.glBindTexture(GL11.GL_TEXTURE_2D, 0);
+                if (mainFormatForFormatCheck == GL30.GL_DEPTH32F_STENCIL8) {
+                    IPCGlobal.useSeparatedStencilFormat = true;
+                } else if (mainFormatForFormatCheck == GL30.GL_DEPTH24_STENCIL8) {
+                    IPCGlobal.useSeparatedStencilFormat = false;
+                }
+            }
         }
-        
+
         CHelper.checkGlError();
-        
+
         for (SecondaryFrameBuffer deferredFb : deferredFbs) {
             deferredFb.prepare();
             IPPortingLibCompat.setIsStencilEnabled(deferredFb.fb, true);
@@ -135,6 +160,28 @@ public class IrisPortalRenderer extends PortalRenderer {
             
             int errorCode = GL11.glGetError();
             if (errorCode != GL_NO_ERROR) {
+                int mainDepthTex = mcFrameBuffer.getDepthTextureId();
+                int deferredDepthTex = deferredFbs[portalLayer].fb.getDepthTextureId();
+                int mainInternalFormat = 0;
+                int deferredInternalFormat = 0;
+                if (mainDepthTex > 0) {
+                    GL11.glBindTexture(GL11.GL_TEXTURE_2D, mainDepthTex);
+                    mainInternalFormat = GL11.glGetTexLevelParameteri(GL11.GL_TEXTURE_2D, 0, GL11.GL_TEXTURE_INTERNAL_FORMAT);
+                }
+                if (deferredDepthTex > 0) {
+                    GL11.glBindTexture(GL11.GL_TEXTURE_2D, deferredDepthTex);
+                    deferredInternalFormat = GL11.glGetTexLevelParameteri(GL11.GL_TEXTURE_2D, 0, GL11.GL_TEXTURE_INTERNAL_FORMAT);
+                }
+                GL11.glBindTexture(GL11.GL_TEXTURE_2D, 0);
+                qouteall.q_misc_util.Helper.LOGGER.error(
+                    "[ImmPtl] Depth blit from main framebuffer ({}x{}, depthTex={}, internalFormat=0x{}) " +
+                        "to deferred framebuffer ({}x{}, depthTex={}, internalFormat=0x{}) failed with GL error 0x{}",
+                    mcFrameBuffer.viewWidth, mcFrameBuffer.viewHeight,
+                    mainDepthTex, Integer.toHexString(mainInternalFormat),
+                    deferredFbs[portalLayer].fb.viewWidth, deferredFbs[portalLayer].fb.viewHeight,
+                    deferredDepthTex, Integer.toHexString(deferredInternalFormat),
+                    Integer.toHexString(errorCode)
+                );
                 IPGlobal.renderMode = IPGlobal.RenderMode.compatibility;
                 CHelper.printChat("[Immersive Portals]" +
                     "Switched to compatibility portal rendering mode." +

--- a/src/main/java/qouteall/imm_ptl/core/compat/mixin/distanthorizons/MixinDhClientApi.java
+++ b/src/main/java/qouteall/imm_ptl/core/compat/mixin/distanthorizons/MixinDhClientApi.java
@@ -1,0 +1,40 @@
+package qouteall.imm_ptl.core.compat.mixin.distanthorizons;
+
+import com.seibel.distanthorizons.core.api.internal.ClientApi;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import qouteall.imm_ptl.core.render.context_management.PortalRendering;
+
+/**
+ * Distant Horizons' shader-pipeline LOD render call (invoked from within Iris's
+ * composite/deferred passes) does synchronous LOD data prep for whatever view is
+ * currently being rendered. When Immersive Portals renders a portal's alternate-world
+ * content, this gets invoked a second time for that separate view, and DH generating
+ * LOD data on demand for a viewpoint it hasn't cached causes multi-hundred-millisecond
+ * frame stalls (confirmed via the client render profiler: a single tick spent 98% of a
+ * 937ms frame inside this call while portal content was rendering). Skip it during
+ * portal rendering -- normal LOD rendering for the player's actual surroundings is
+ * unaffected since PortalRendering.isRendering() is only true during that sub-pass.
+ */
+@Mixin(value = ClientApi.class, remap = false)
+public class MixinDhClientApi {
+    // Both public entry points end up calling the private renderLodLayer(boolean), which is
+    // where the actual expensive LOD work happens -- Iris's opaque/terrain composite pass goes
+    // through renderLods() while its translucent pass goes through renderDeferredLodsForShaders(),
+    // so both need cancelling during portal rendering, not just one.
+    @Inject(method = "renderLods", at = @At("HEAD"), cancellable = true)
+    private void onRenderLods(CallbackInfo ci) {
+        if (PortalRendering.isRendering()) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "renderDeferredLodsForShaders", at = @At("HEAD"), cancellable = true)
+    private void onRenderDeferredLodsForShaders(CallbackInfo ci) {
+        if (PortalRendering.isRendering()) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/qouteall/imm_ptl/core/compat/mixin/sodium/MixinSodiumOcclusionCuller.java
+++ b/src/main/java/qouteall/imm_ptl/core/compat/mixin/sodium/MixinSodiumOcclusionCuller.java
@@ -1,6 +1,7 @@
 package qouteall.imm_ptl.core.compat.mixin.sodium;
 
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
+import net.caffeinemc.mods.sodium.client.render.chunk.lists.RenderSectionVisitor;
 import net.caffeinemc.mods.sodium.client.render.chunk.occlusion.OcclusionCuller;
 import net.caffeinemc.mods.sodium.client.render.viewport.Viewport;
 import net.minecraft.core.SectionPos;
@@ -41,7 +42,7 @@ public abstract class MixinSodiumOcclusionCuller {
     )
     boolean modifyUseOcclusionCulling(
         boolean originalValue,
-        OcclusionCuller.Visitor visitor, Viewport viewport, float searchDistance, boolean useOcclusionCulling, int frame
+        RenderSectionVisitor visitor, Viewport viewport, float searchDistance, boolean useOcclusionCulling, int frame
     ) {
         boolean doUseOcclusionCulling = PortalRendering.shouldEnableSodiumCaveCulling();
         

--- a/src/main/java/qouteall/imm_ptl/core/compat/mixin/sodium/MixinSodiumViewport.java
+++ b/src/main/java/qouteall/imm_ptl/core/compat/mixin/sodium/MixinSodiumViewport.java
@@ -10,7 +10,7 @@ import qouteall.imm_ptl.core.compat.sodium_compatibility.SodiumInterface;
 @Mixin(value = Viewport.class, remap = false)
 public class MixinSodiumViewport {
     @Redirect(
-        method = "isBoxVisible",
+        method = "isBoxVisibleDirect",
         at = @At(
             value = "INVOKE",
             target = "Lnet/caffeinemc/mods/sodium/client/render/viewport/frustum/Frustum;testAab(FFFFFF)Z"

--- a/src/main/resources/imm_ptl_compat.mixins.json
+++ b/src/main/resources/imm_ptl_compat.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_17",
   "plugin": "qouteall.imm_ptl.core.compat.IPCompatMixinPlugin",
   "mixins": [
+    "distanthorizons.MixinDhClientApi",
     "flywheel.MixinFlywheelCrumblingRenderer",
     "flywheel.MixinFlywheelProgramCompiler",
     "flywheel.MixinFlywheelQuadConverter",


### PR DESCRIPTION
Tested together in a real modpack running Sodium 0.8.12, Iris 1.8.14-beta.1, and Distant Horizons 3.2.0 on NeoForge 1.21.1. Three separate issues, three commits:

## 1. Sodium 0.8.x API compat (`OcclusionCuller.Visitor` / `isBoxVisible`)

`OcclusionCuller.Visitor` was promoted to a top-level interface (`RenderSectionVisitor`), and `Viewport.isBoxVisible`'s old 6-float AABB signature was split into `isBoxVisible(int,int,int)` (section-coordinate culling) and `isBoxVisibleDirect(float,float,float,float)` (direct center+radius test, which is what now calls `Frustum.testAab`).

This overlaps with #68 — I arrived at essentially the identical fix independently before finding that PR, which is a good sign both are correct. Credit to whoever opened #68 for the same diagnosis. This PR additionally switches the build to compile against CaffeineMC's own maven for Sodium instead of Modrinth's published artifact, which wraps the real classes in a JarInJar shim that Gradle's compile classpath can't see through (this was blocking a clean build against 0.8.x).

## 2. Iris depth-buffer format mismatch + framebuffer thrashing

With a shaderpack active, portals would either render through occluding geometry or silently fall back to compatibility rendering mode (losing portal-in-portal). Root cause: the deferred framebuffers' stencil-enabled state was decided by a GPU-vendor heuristic that doesn't reliably reflect what Iris actually does to the main render target's depth texture (Iris manages that texture directly, bypassing this mod's own stencil tracking). The depth blit between the two requires matching internal formats, so a stale heuristic caused `GL_INVALID_OPERATION` and the fallback. Fixed by querying the main target's actual current format via `glGetTexLevelParameteri` and using that as ground truth.

Also fixed a related stutter: the deferred framebuffer array was sized off `PortalRendering.getMaxPortalLayer()`, which drops to 1 whenever `RenderStates.isLaggy` is true. Every `isLaggy` toggle triggered a full destroy-and-recreate of every deferred framebuffer — expensive enough to cause more lag, creating a self-sustaining stutter cycle. Sizing off the static config value instead keeps the array stable without changing the lag-adaptive behavior itself.

## 3. Distant Horizons compat

DH's LOD render call does synchronous LOD generation for whatever view is currently rendering. When this mod renders a portal's alternate-world content, DH's call fires a second time for that separate view, and generating LOD data on demand for an uncached viewpoint caused frame stalls of 900ms+ (confirmed via Minecraft's F3+L render profiler — a single tick spent 98% of a 937ms frame inside DH's render call during portal rendering). Both of DH's render entry points (`renderLods()` for the opaque pass, `renderDeferredLodsForShaders()` for Iris's translucent composite pass) are now skipped while `PortalRendering.isRendering()` is true. Normal LOD rendering for the player's actual surroundings is unaffected.

---

Noticed the project's had a couple of correct, complete PRs (including #68) sitting unreviewed for a while — no pressure, just flagging in case the queue's been out of sight. Happy to adjust anything if you'd like a different approach on any of these.